### PR TITLE
Modified the link to aws policy json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The goal is to see the Dynatrace AWS Monitoring Dashboard populuated with data p
 1. For Dynatrace SaaS please open [Dynatrace Doc: How do I start Amazon Web Service Monitoring](https://www.dynatrace.com/support/help/cloud-platforms/amazon-web-services/how-do-i-start-amazon-web-services-monitoring/). For Dynatrace Managed check out [Dynatrace Doc: How do I monitor AWS using role-based access?](https://help.dynatrace.com/dynatrace-managed/dynatrace-server/how-do-i-monitor-aws-using-role-based-access/)
 2. Follow the instructions for either Role or Key-based authentication
 3. Tip for Role-based: Make sure you remember the Role Name, your AWS Account ID and the External ID while creating the role. You will need it at the very last step of the configuration
-4. Tip for Key-based authentication: For quick evaluation I think this is the easiest path assuming your AWS User has the [required policies attached](http://assets.dynatrace.com/global/resources/aws-policy.json).
+4. Tip for Key-based authentication: For quick evaluation I think this is the easiest path assuming your AWS User has the [required policies attached](https://www.dynatrace.com/support/help/codefiles/aws/aws-policy.json).
 4. Once done Validate that Dynatrace shows data in the AWS Dashboard. Simply click on "AWS" in the Dynatrace menu and you should see a simliar screen as shown above
 
 **Costs:** AWS charges for CloudWatch API access when exceeding 1 million requests. More details can be found in the Dynatrace and CloudWatch Documentation


### PR DESCRIPTION
The file hosted on assets is outdated. See https://support.dynatrace.com/supportportal/browse/SUP-30728 
Replaced it with the link to file from the doc that is updated on regular basis

The tutorial overall should also be updated, the changing the policy is the quickest fix.